### PR TITLE
Use select for emoji style field

### DIFF
--- a/plugin.json
+++ b/plugin.json
@@ -10,8 +10,9 @@
     },
     {
       "field": "params.faviconique_style",
-      "label": "Emoji style (apple / twitter / facebook / google)",
-      "type": "string"
+      "label": "Emoji style",
+      "type": "select",
+      "options": ["apple", "twitter", "facebook", "google"]
     },
     {
       "field": "params.faviconique_title",


### PR DESCRIPTION
## Summary
- use select type for emoji style configuration
- restrict allowed emoji styles to Apple, Twitter, Facebook, or Google

## Testing
- `jq . plugin.json`


------
https://chatgpt.com/codex/tasks/task_e_689b0d1727248328adad6eed1b9642a4