### PR TITLE
Render theme meta tags only when color specified

### DIFF
--- a/layouts/partials/microblog_head.html
+++ b/layouts/partials/microblog_head.html
@@ -26,8 +26,10 @@
 
 <meta name="apple-mobile-web-app-title" content="{{ $title }}">
 <meta name="application-name" content="{{ $title }}">
+{{- if ne $theme "#000000" }}
 <meta name="theme-color" content="{{ $theme }}">
 <meta name="msapplication-TileColor" content="{{ $theme }}">
+{{- end }}
 {{- if $capable }}
 <meta name="apple-mobile-web-app-capable" content="yes">
 <meta name="mobile-web-app-capable" content="yes">


### PR DESCRIPTION
## Summary
- Only emit `theme-color` and `msapplication-TileColor` meta tags when a theme color is explicitly set (not the default placeholder).

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689b0d2a29888328b16d5b65146d5bbc