### PR TITLE
Add PWA manifest for home screen install

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 **Turn a single emoji into a cross‑browser favicon – no image export, no build steps.**
 
-Faviconique+ is a Micro.blog plug‑in that takes one emoji and serves it as PNG favicons via **EmojiCDN**. It also provides an Apple touch icon, optional standalone (full‑screen) mode, and a configurable browser UI color. Works in Safari, Chrome, Firefox, Edge — **no local image generation** needed.
+Faviconique+ is a Micro.blog plug‑in that takes one emoji and serves it as PNG favicons via **EmojiCDN**. It also provides an Apple touch icon and a configurable browser UI color. Works in Safari, Chrome, Firefox, Edge — **no local image generation** needed.
 
 > Credits: Inspired by the original [Faviconique](https://micro.blog/account/plugins/view/141) by Sven Dahlstrand. This plug‑in focuses on emoji-only favicons via a CDN and adds a few Micro.blog‑specific quality‑of‑life options.
 
@@ -15,13 +15,13 @@ Faviconique+ is a Micro.blog plug‑in that takes one emoji and serves it as PNG
 - 📐 **Multiple sizes out of the box**
   - 16×16, 32×32, 48×48, 96×96, 192×192, 512×512
   - Plus **Apple touch icon** 180×180
+- 📱 **Add to Home Screen**
+  - Web App Manifest + optional iOS meta tags for app‑like launch
 - 🚀 **Fast loading**
   - `preconnect` + `dns-prefetch` to EmojiCDN
   - Cache‑buster on URLs to avoid stale favicons
 - 🏷️ **Configurable names** for home‑screen/app surfaces
   - Sets `apple-mobile-web-app-title` and `application-name`
-- 🧭 **Optional full‑screen (standalone) mode**
-  - Adds `apple-mobile-web-app-capable` and `mobile-web-app-capable` when enabled
 - 🎨 **Theme color** for browser UI (Android/desktop browsers, Windows tiles)
   - Sets `theme-color` and `msapplication-TileColor`
 - 🔧 **Zero local processing** – everything via CDN
@@ -35,10 +35,16 @@ Fields in **Plugins → Faviconique+ → Settings**:
 - **Emoji (only one)** – e.g. `🌱` *(required)*
 - **Emoji style** – `apple`, `twitter`, `facebook`, or `google` *(required)*
 - **Home screen title (optional)** – overrides the saved shortcut/app name
-- **Enable standalone (full screen) mode** – toggles iOS/Android standalone meta tags
 - **Theme color for browser UI** – used for `theme-color` and Windows tiles
+- **Web app display (standalone or browser)** – choose `standalone` for an app‑like window or `browser` for a normal tab
 
 > Tip: Placeholders in the UI are **not** saved values. Enter your own values and click **Update Settings**.
+
+---
+
+## Add to Home Screen
+
+Once configured, visit your site on a mobile browser and use **Add to Home Screen**. The generated `manifest.webmanifest` and optional iOS meta tags launch in your chosen display mode with the selected emoji icon and theme color.
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ Fields in **Plugins → Faviconique+ → Settings**:
 - **Emoji style** – `apple`, `twitter`, `facebook`, or `google` *(required)*
 - **Home screen title (optional)** – overrides the saved shortcut/app name
 - **Theme color for browser UI** – used for `theme-color` and Windows tiles
-- **Web app display (standalone or browser)** – choose `standalone` for an app‑like window or `browser` for a normal tab
+- **Web app display (`standalone` or `browser`)** – choose `standalone` for an app‑like window or `browser` for a normal tab
 
 > Tip: Placeholders in the UI are **not** saved values. Enter your own values and click **Update Settings**.
 

--- a/layouts/manifest.webmanifest
+++ b/layouts/manifest.webmanifest
@@ -1,0 +1,29 @@
+{{- $p := .Site.Params -}}
+{{- $emoji := (index $p "faviconique_emoji") | default "🌱" -}}
+{{- $style := (index $p "faviconique_style") | default "apple" -}}
+{{- $title := (index $p "faviconique_title") | default .Site.Title -}}
+{{- $theme := (index $p "faviconique_theme_color") | default "#000000" -}}
+{{- $display := (index $p "faviconique_display") | default "standalone" -}}
+{{- $cdn := "https://emojicdn.elk.sh" -}}
+{{- $v := printf "&v=%d" now.Unix -}}
+{{- $base := printf "%s/%s?style=%s&size=" $cdn (urlquery $emoji) $style -}}
+{
+  "name": "{{ $title }}",
+  "short_name": "{{ $title }}",
+  "start_url": "/",
+  "display": "{{ $display }}",
+  "background_color": "{{ $theme }}",
+  "theme_color": "{{ $theme }}",
+  "icons": [
+    {
+      "src": "{{ $base }}192{{ $v }}",
+      "sizes": "192x192",
+      "type": "image/png"
+    },
+    {
+      "src": "{{ $base }}512{{ $v }}",
+      "sizes": "512x512",
+      "type": "image/png"
+    }
+  ]
+}

--- a/layouts/partials/microblog_head.html
+++ b/layouts/partials/microblog_head.html
@@ -1,14 +1,10 @@
 {{- $p := .Site.Params -}}
-{{- $plugins := (index $p "plugins") | default dict -}}
-{{- $me := (index $plugins "plugin-faviconique-plus") | default dict -}}
-{{- $group := (index $p "faviconique") | default dict -}}
-
-{{- $emoji := (or (index $p "faviconique_emoji") (index $me "faviconique_emoji") (index $group "emoji")) | default "🌱" -}}
-{{- $style := (or (index $p "faviconique_style") (index $me "faviconique_style") (index $group "style")) | default "apple" -}}
+{{- $emoji := (index $p "faviconique_emoji") | default "🌱" -}}
+{{- $style := (index $p "faviconique_style") | default "apple" -}}
+{{- $title := (index $p "faviconique_title") | default .Site.Title -}}
+{{- $theme := (index $p "faviconique_theme_color") | default "#000000" -}}
+{{- $display := (index $p "faviconique_display") | default "standalone" -}}
 {{- $cdn := "https://emojicdn.elk.sh" -}}
-{{- $title := (or (index $p "faviconique_title") (index $me "faviconique_title") (index $group "title") .Site.Title) -}}
-{{- $capable := (or (index $p "faviconique_webapp_capable") (index $me "faviconique_webapp_capable") (index $group "webapp_capable") ) -}}
-{{- $theme := (or (index $p "faviconique_theme_color") (index $me "faviconique_theme_color") (index $group "theme_color") ) | default "#000000" -}}
 {{- $v := printf "&v=%d" now.Unix -}}
 {{- $base := printf "%s/%s?style=%s&size=" $cdn (urlquery $emoji) $style -}}
 
@@ -23,12 +19,13 @@
 <link rel="icon" type="image/png" sizes="512x512" href="{{$base}}512{{$v}}">
 <link rel="shortcut icon" type="image/png" href="{{$base}}32{{$v}}">
 <link rel="apple-touch-icon" sizes="180x180" href="{{$base}}180{{$v}}">
+<link rel="manifest" href="{{ "manifest.webmanifest" | relURL }}">
 
+{{- if eq $display "standalone" }}
+<meta name="apple-mobile-web-app-capable" content="yes">
+<meta name="apple-mobile-web-app-status-bar-style" content="default">
+{{- end }}
 <meta name="apple-mobile-web-app-title" content="{{ $title }}">
 <meta name="application-name" content="{{ $title }}">
 <meta name="theme-color" content="{{ $theme }}">
 <meta name="msapplication-TileColor" content="{{ $theme }}">
-{{- if $capable }}
-<meta name="apple-mobile-web-app-capable" content="yes">
-<meta name="mobile-web-app-capable" content="yes">
-{{- end }}

--- a/plugin.json
+++ b/plugin.json
@@ -1,7 +1,7 @@
 {
-  "version": "0.1.8",
+  "version": "0.2.1",
   "title": "Faviconique+",
-  "description": "Emoji favicon via EmojiCDN for all browsers.",
+  "description": "Emoji favicon via EmojiCDN with web app manifest for installs.",
   "fields": [
     {
       "field": "params.faviconique_emoji",
@@ -21,14 +21,15 @@
     },
     {
       "field": "params.faviconique_theme_color",
-      "label": "Theme color for fullscreen browser app",
+      "label": "Theme color for browser UI",
       "type": "color",
       "placeholder": "#000000"
     },
     {
-      "field": "params.faviconique_webapp_capable",
-      "label": "Enable standalone (full screen) app mode",
-      "type": "boolean"
+      "field": "params.faviconique_display",
+      "label": "Web app display (standalone or browser)",
+      "type": "string",
+      "placeholder": "standalone"
     }
   ]
 }

--- a/plugin.json
+++ b/plugin.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.2.1",
+  "version": "0.2.2",
   "title": "Faviconique+",
   "description": "Emoji favicon via EmojiCDN with web app manifest for installs.",
   "fields": [


### PR DESCRIPTION
## Summary
- read favicon emoji, title, theme color, and display mode directly from site params
- allow choosing standalone or browser launch via `faviconique_display`
- document new display option and bump plugin to version 0.2.1

## Testing
- `npm test` *(fails: ENOENT: no such file or directory, open '/workspace/plugin-faviconique-plus/package.json')*

------
https://chatgpt.com/codex/tasks/task_e_689b0d79b5248328add0c8d8d4e59097