### PR TITLE
feat: make manifest display configurable

### DIFF
--- a/layouts/manifest.webmanifest
+++ b/layouts/manifest.webmanifest
@@ -8,13 +8,14 @@
 {{- $cdn := "https://emojicdn.elk.sh" -}}
 {{- $title := (or (index $p "faviconique_title") (index $me "faviconique_title") (index $group "title") .Site.Title) -}}
 {{- $theme := (or (index $p "faviconique_theme_color") (index $me "faviconique_theme_color") (index $group "theme_color")) | default "#000000" -}}
+{{- $display := (or (index $p "faviconique_display") (index $me "faviconique_display") (index $group "display")) | default "standalone" -}}
 {{- $v := printf "&v=%d" now.Unix -}}
 {{- $base := printf "%s/%s?style=%s&size=" $cdn (urlquery $emoji) (urlquery $style) -}}
 {
   "name": "{{ $title }}",
   "short_name": "{{ $title }}",
   "start_url": "/",
-  "display": "standalone",
+  "display": "{{ $display }}",
   "background_color": "{{ $theme }}",
   "theme_color": "{{ $theme }}",
   "icons": [


### PR DESCRIPTION
## Summary
- allow customizing PWA manifest display via `faviconique_display`

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689b2d2c704483288ec5b7a61b84a91c