### PR TITLE
Respect plugin-scoped favicon params in microblog head

### DIFF
--- a/layouts/partials/microblog_head.html
+++ b/layouts/partials/microblog_head.html
@@ -1,9 +1,13 @@
 {{- $p := .Site.Params -}}
-{{- $emoji := (index $p "faviconique_emoji") | default "🌱" -}}
-{{- $style := (index $p "faviconique_style") | default "apple" -}}
-{{- $title := (index $p "faviconique_title") | default .Site.Title -}}
-{{- $theme := (index $p "faviconique_theme_color") | default "#000000" -}}
-{{- $display := (index $p "faviconique_display") | default "standalone" -}}
+{{- $plugins := (index $p "plugins") | default dict -}}
+{{- $me := (index $plugins "plugin-faviconique-plus") | default dict -}}
+{{- $group := (index $p "faviconique") | default dict -}}
+
+{{- $emoji := (or (index $p "faviconique_emoji") (index $me "faviconique_emoji") (index $group "emoji")) | default "🌱" -}}
+{{- $style := (or (index $p "faviconique_style") (index $me "faviconique_style") (index $group "style")) | default "apple" -}}
+{{- $title := (or (index $p "faviconique_title") (index $me "faviconique_title") (index $group "title") .Site.Title) -}}
+{{- $theme := (or (index $p "faviconique_theme_color") (index $me "faviconique_theme_color") (index $group "theme_color")) | default "#000000" -}}
+{{- $display := (or (index $p "faviconique_display") (index $me "faviconique_display") (index $group "display")) | default "standalone" -}}
 {{- $cdn := "https://emojicdn.elk.sh" -}}
 {{- $v := printf "&v=%d" .Site.LastChange.Unix -}}
 {{- $base := printf "%s/%s?style=%s&size=" $cdn (urlquery $emoji) (urlquery $style) -}}


### PR DESCRIPTION
## Summary
- look up favicon params from plugin scope and group, mirroring manifest

## Testing
- `hugo` *(fails: Unable to locate config file or config directory)*

------
https://chatgpt.com/codex/tasks/task_e_689b2d2ed488832880af4cca0916d964