### PR TITLE
Enable Web App Manifest generation

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,10 +44,7 @@ Fields in **Plugins → Faviconique+ → Settings**:
 
 ## Add to Home Screen
 
-Once configured, visit your site on a mobile browser and use **Add to Home Screen**. The generated `manifest.webmanifest` and optional iOS meta tags launch in your chosen display mode with the selected emoji icon and theme color.
-=======
-Once configured, visit your site on a mobile browser and use **Add to Home Screen**. The generated `manifest.webmanifest` and iOS
-meta tags enable a standalone launch with your chosen emoji icon and theme color.
+Once configured, visit your site on a mobile browser and use **Add to Home Screen**. The generated `manifest.webmanifest` and optional iOS meta tags launch in your chosen display mode with the selected emoji icon and theme color. The plug-in now ships with Hugo output settings that automatically generate `manifest.webmanifest` at the site root, so no additional configuration is required.
 
 ---
 

--- a/config.json
+++ b/config.json
@@ -1,0 +1,5 @@
+{
+  "outputs": {
+    "home": ["HTML", "RSS", "JSON", "WebAppManifest"]
+  }
+}


### PR DESCRIPTION
## Summary
- document built-in manifest generation in plugin docs
- add Hugo outputs config so `manifest.webmanifest` is produced at site root

## Testing
- `npm test` *(fails: ENOENT, could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689b3fdd1dec83288e726a4b387e1c37